### PR TITLE
re-use existing functions and loop over grid cell years

### DIFF
--- a/HARP-2021-2022/get_lseg_data.R
+++ b/HARP-2021-2022/get_lseg_data.R
@@ -49,8 +49,8 @@ get_lseg_data <- function(landseg, date_range="all_data", metsite="http://deq1.b
 
 # use
 # dfRAD, dfTMP, and dfPRC are used as inputs to the get_lseg_summary_stats() function
-landseg <- "A51197"
-lseg_data <- get_lseg_data(landseg = landseg)
-dfRAD <- lseg_data$dfRAD
-dfTMP <- lseg_data$dfTMP
-dfPRC <- lseg_data$dfPRC
+# landseg <- "A51197"
+# lseg_data <- get_lseg_data(landseg = landseg)
+# dfRAD <- lseg_data$dfRAD
+# dfTMP <- lseg_data$dfTMP
+# dfPRC <- lseg_data$dfPRC

--- a/HARP-2021-2022/get_rolling_avg_workflow.R
+++ b/HARP-2021-2022/get_rolling_avg_workflow.R
@@ -15,8 +15,8 @@ site <- "http://deq1.bse.vt.edu:81/d.dh"
 basepath <- '/var/www/R';
 source(paste(basepath,'config.R',sep='/'))
 #source nldas functions
-source(paste(github_location,"HARParchive/HARP-2021-2022","lseg_functions.R", sep = "/"))
-
+source("https://raw.githubusercontent.com/HARPgroup/HARParchive/master/HARP-2021-2022/lseg_functions.R")
+source("https://raw.githubusercontent.com/HARPgroup/HARParchive/master/HARP-2021-2022/get_lseg_data.R")
 
 ###########################################if analyzing land segment run these lines below
 #declare inputs
@@ -26,12 +26,11 @@ endDate <- "2020123123" #formatted YYYYMMDDHH
 
 #reading in precip land segment data sets (run these lines if you want to analyze a land segment)
 #dfPRC <- read.table(paste0("http://deq1.bse.vt.edu:81/met/out/lseg_csv/",startDate,"-",endDate,"/",landseg,".PRC"), header = FALSE, sep = ",")
-site <- paste0("http://deq1.bse.vt.edu:81/met/out/lseg_csv/",startDate,"-",endDate,"/")
-dfPRC <- data.table::fread(paste0(site,landseg,".PRC"))
-
-#formatting columns
-colnames(dfPRC) = c("year","month","day","hour","precip")
-dfPRC$date <- as.Date(paste(dfPRC$year,dfPRC$month,dfPRC$day, sep="-"))
+dfLSEG <- get_lseg_data (landseg)
+dfPRC <- as.data.frame(dfLSEG$dfPRC)
+dfn <- names(dfPRC)
+dfn[which(dfn == 'PRC')] <- "precip"
+names(dfPRC) <- dfn
 
 #creating table from function using rolling_avg_df
 rolling_avg_df <- get_rolling_avg_df(df = dfPRC, metric = "precip")
@@ -46,19 +45,38 @@ plots[2]
 ##########################################if analyzing grid cell run these lines below
 #declare inputs
 grid <- 'x393y97'
-year <- "1984"
-
-#reading in precip data from grid cell
-#dfPRC <- read.table(paste0("http://deq1.bse.vt.edu:81/met/out/grid_met_csv/",year,"/",grid,"zPP.txt"), header = FALSE)
-site <- paste0("http://deq1.bse.vt.edu:81/met/out/grid_met_csv/",year,"/")
-dfPRC <- data.table::fread(paste0(site,grid,"zPP.txt"))
-
-#formatting columns
-colnames(dfPRC) = c("year","month","day","hour","precip")
-dfPRC$date <- as.Date(paste(dfPRC$year,dfPRC$month,dfPRC$day, sep="-"))
+syear <- substr(startDate,1,4)
+eyear <- substr(endDate,1,4)
+dfPRCall = FALSE
+for (iyr in syear:eyear) {
+  #reading in precip data from grid cell
+  #dfPRC <- read.table(paste0("http://deq1.bse.vt.edu:81/met/out/grid_met_csv/",year,"/",grid,"zPP.txt"), header = FALSE)
+  site <- paste0("http://deq1.bse.vt.edu:81/met/out/grid_met_csv/",iyr,"/")
+  dfPRC <- data.table::fread(paste0(site,grid,"zPP.txt"))
+  #formatting columns
+  colnames(dfPRC) = c("year","month","day","hour","precip")
+  dfPRC$date <- as.Date(
+    paste(dfPRC$year,dfPRC$month,dfPRC$day, 
+    sep="-")
+  )
+  if (is.logical(dfPRCall)) {
+    dfPRCall <- dfPRC
+  } else {
+    dfPRCall <- sqldf(
+      "SELECT * from (
+         SELECT * from dfPRCall
+         UNION
+         SELECT * from dfPRC
+       )
+       ORDER BY date
+      "
+    )
+  }
+  
+}
 
 #creating table from function using rolling_avg_df
-rolling_avg_df <- get_rolling_avg_df(df = dfPRC, metric = "precip")
+rolling_avg_df <- get_rolling_avg_df(df = dfPRCall, metric = "precip")
 
 #creating plots from generate_rolling_avg_precip_plots (change spatial unit input according to your dataframe
 plots <- generate_rolling_avg_precip_plots(rolling_avg_df = rolling_avg_df, spatial_unit = grid)


### PR DESCRIPTION
Couple of style & coding choice comments:
- The first tweak I did to this was to source the functions from the github raw rather than a local directory path.  This is important when we are doing updates rapidly since other team members may not remember to do a new pull on their repo
- I re-used the function we developed last week `get_lseg_data()` to pull the land segment stuff.  This is important because we want to avoid redundant code development for the downloads.
- I added a loop over the grid cell data download, and used an `SQL/sqldf` function `UNION` to append each successive years data.  This technique could prove useful in the "mash-up" script, so I add it here for your convenience.  In most cases, my own preference is that using SQL is way better than dplyr because it is 1) portable, and 2) more readable.

Thanks for the review and thanks again for the good work on this!