### PR TITLE
set param in read.csv to allow special characters in header

### DIFF
--- a/HARP-2022-Summer/AutomatedScripts/SubshedsCreation/area_propor.R
+++ b/HARP-2022-Summer/AutomatedScripts/SubshedsCreation/area_propor.R
@@ -17,7 +17,7 @@ sub_da <- as.numeric(argst[4])
 #file <- 'HARParchive/HARP-2022-Summer/AutomatedScripts/SubshedsCreation/land_use_2013VAHYDRO2018615.csv'
 #-- -- 
 
-file <- read.csv(file_path, sep=',')
+file <- read.csv(file_path, sep=',', check.names = F)
 
 area_propor <- function(
     subshed,


### PR DESCRIPTION
Figured out the bug where R changes the CSV header. The function  `read.csv` has a specific parameter `check.names = F` to tell it not to do that. @megpritch @juliabruneau in case we run into this again (prolly we will!)