### PR TITLE
adopt new streamlined foundation data paths

### DIFF
--- a/HARP-2023-Summer/Mapping/Dataframe_Generator.Rmd
+++ b/HARP-2023-Summer/Mapping/Dataframe_Generator.Rmd
@@ -73,7 +73,7 @@ if (overwrite_files==TRUE) {
 
 #----Pull Data----
 #---Facility Data---
-foundatn_mp <- fread(paste0(github_location, "/Foundational_Data/foundation_dataset_mgy.csv")) #foundational measuring pt(mp)/sources data
+foundatn_mp <- fread(paste0(github_location, "/Foundational_Data/data/foundation_dataset_mgy.csv")) #foundational measuring pt(mp)/sources data
 
 if (featr_type=="facility") { #specified model metrics will be pulled @ the facility-level for every specified runid using om_vahydro_metric_grid()
   
@@ -99,7 +99,7 @@ if (featr_type=="facility") { #specified model metrics will be pulled @ the faci
     ds=ds
   )
   #pull facility-level geometry to join with model data:
-  f_geo <- fread(paste0(github_location, "/Foundational_Data/2023/facilities_all_geom.csv"))
+  f_geo <- fread(paste0(github_location, "/Foundational_Data/data/facilities_all_geom.csv"))
 } 
 #---Watershed/Riverseg Data---
 #rsegs <- ds$get('dh_feature', config=list(ftype='vahydro',bundle='watershed')) ## VAhydro gives errors

--- a/HARP-2023-Summer/Mapping/Dataframe_Generator.Rmd
+++ b/HARP-2023-Summer/Mapping/Dataframe_Generator.Rmd
@@ -73,8 +73,7 @@ if (overwrite_files==TRUE) {
 
 #----Pull Data----
 #---Facility Data---
-# foundatn_mp <- fread(paste0(github_location, "/Foundational_Data/2023/foundation_dataset_mgy_1982-2022_HARP_11-16.csv")) #foundational measuring pt(mp)/sources data
-foundatn_mp <- fread(paste0(github_location, "/Foundational_Data/2023/foundation_dataset_mgy_1982-2022_HARP_02-05.csv")) #foundational measuring pt(mp)/sources data
+foundatn_mp <- fread(paste0(github_location, "/Foundational_Data/foundation_dataset_mgy.csv")) #foundational measuring pt(mp)/sources data
 
 if (featr_type=="facility") { #specified model metrics will be pulled @ the facility-level for every specified runid using om_vahydro_metric_grid()
   


### PR DESCRIPTION
Hey @glenncampagna @EllaF21 @megpritch - Brendan and I worked out a change to the foundation data set so that there will no longer be any need to change the file path as it is updated.  This PR adopts that change, you'll need to update next time you sit down to work - thanks!

Also (all include: @gmahadwar and @BrendanBrogan) note that I pushed a separate change to the Dataframe generator to use the FIPS code (see #1176 ) instead of the locality name when doing a locality version of the Rmd summary.  Happy to report that this appears to work nicely, at least from a very cursory review. I am tracking my progress for that experiment in #1130 )