### PR TITLE
reinitialize rsegs_display each loop

### DIFF
--- a/HARP-2023-Summer/Mapping/WSP_Regional_Summaries.Rmd
+++ b/HARP-2023-Summer/Mapping/WSP_Regional_Summaries.Rmd
@@ -725,10 +725,11 @@ for (k in 1:length(run_config$riverseg_metrics)){ #loop thru metrics
 #NEW TABLE WITH RUNSET
 
 rivTables <- list() #to store dataframes for each drought metric
-rseg_display <- st_drop_geometry(rsegs) #copy of rsegs 
+rseg_no_geom <- st_drop_geometry(rsegs) #copy of rsegs 
 
   # base info
 for (k in 1:length(run_config$riverseg_metrics)){
+  rseg_display <- rseg_no_geom # must reinitialize rseg_display each time since we remove unused columns below
   display_metric <- run_config$riverseg_metrics[[k]]$metric
   display_column <- run_config$riverseg_metrics[[k]]$column_name
   table_cols <- unlist(run_config$riverseg_metrics[[k]]$tables_cols)


### PR DESCRIPTION
@EllaF21 - I replicated your issue and made a fix.  Basically, we had initialized `rseg_display` lutside the loop, as a copy of rsegs, which is awesome, except that once it had run once, you had removed all the columns from rseg_display that were *not* used in the 1st table, thus, when you got to the 2nd table, those columns were no longer there.  So, by reinitializing `rseg_display` at the top of each loop, you start fresh with the full set of columns to extract and format.