### PR TITLE
Issue 1183 bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .Rhistory
 Dataframe_Generator.html
 
+.Rproj.user
+
+.Rproj

--- a/HARP-2023-Summer/Mapping/Dataframe_Generator.Rmd
+++ b/HARP-2023-Summer/Mapping/Dataframe_Generator.Rmd
@@ -15,6 +15,8 @@ params:
   overwrite_files: TRUE #if FALSE -> will stop execution if rivseg and feature files already exist
   base_layer_data: FALSE #if FALSE -> will only generate the origin/metric-dependent data for mapping (rsegs, featrs)
                            #if TRUE -> will also re-generate map base-layer data (regions, counties, cities, roads)
+editor_options: 
+  chunk_output_type: console
 ---
 
 ```{r setup}
@@ -80,11 +82,12 @@ if (featr_type=="facility") { #specified model metrics will be pulled @ the faci
   
   facdf <- data.frame()
   for (k in metric_mod) {
+    #create df of model run specifications for om_vahydro_metric_grid()
+    df <- data.frame(runid=runid_list, model_version, metric=k) 
+    #add column to df containing 'runlabel' which will become the metric column
+    #names in featrs$model
+    df$runlabel <- paste0(runid_list, "_", k)
     
-    df <- data.frame(runid=runid_list, model_version, metric=k) #create df of model run specifications for om_vahydro_metric_grid()
-    for(i in 1:length(runid_list)){ #add column to df containing 'runlabel' which will become the metric column names in featrs$model
-      df$runlabel[i] <- paste0(runid_list[i], '_', k)
-    }
     if (is.logical(facdf)) {
       facdf <- df
     } else {

--- a/HARP-2023-Summer/Mapping/WSP_Regional_Summaries.Rmd
+++ b/HARP-2023-Summer/Mapping/WSP_Regional_Summaries.Rmd
@@ -417,18 +417,13 @@ if (show_map == TRUE) {
 
 ```
 
-```{r View Map 1, echo=FALSE, out.width = '100%', out.height='100%', message=TRUE}
-# if (show_map == TRUE) {
-#   knitr::include_graphics(mapfilename) #display map(s) PNG -- not functional inside loop
-#   if (mapMessage == TRUE) {
-#     message("The metric requested does not exist for this map.")
-#     message("Check your syntax/spelling. If correct, then this data has not been measured/modeled")
-#   }
-# }
-
-if (show_map == TRUE) {
-  knitr::include_graphics(mapfilename) #display map(s) as PNG
+```{r View Map 1, echo=FALSE, out.width = '100%', out.height='100%', message=TRUE,eval = show_map}
+knitr::include_graphics(mapfilename) #display map(s) PNG -- not functional inside loop
+if (mapMessage) {
+  message("The metric requested does not exist for this map.")
+  message("Check your syntax/spelling. If correct, then this data has not been measured/modeled")
 }
+
 ```
 
 ```{r Create Table 1, echo=FALSE, message=FALSE, warning=FALSE}


### PR DESCRIPTION
Fixed the bug pointed out in #1183 by ensuring include_graphics() is mentioned by a top-level expression. This is required by include_graphics as mentioned in this [post](https://github.com/yihui/knitr/issues/1260#issuecomment-241942742) by Yihui Xie. Top-level R expressions are described briefly in this [post](https://yihui.org/en/2017/06/top-level-r-expressions/#:~:text=A%20top%2Dlevel%20R%20expression%20is%20usually%20implicitly%20printed.,object%20returned%20by%20the%20expression.). Essentially, include_graphics must be returned by the _if_ statement and should be included last in a series of nested _if_ statements or by itself. This is also why it fails in _for_ loops, though applying it over a vector of filenames may still work. More detail [here](https://github.com/HARPgroup/HARParchive/issues/1183#issuecomment-1959728927)