### PR TITLE
replace missing table names with my best guess

### DIFF
--- a/HARP-2023-Summer/WaterAvailability/WaterAvailability_CaseStudies.Rmd
+++ b/HARP-2023-Summer/WaterAvailability/WaterAvailability_CaseStudies.Rmd
@@ -937,10 +937,10 @@ write.csv(table_Smin, paste0(export_path, 'CaseStudies_table2_Smin_',
 write.csv(table_Storage, paste0(export_path, 'CaseStudies_table3_Storage_', 
                            demand_scenario, '_', baseline_scenario, '_', mif_coef, '.csv')) 
 
-write.csv(table_imp, paste0(export_path, 'CaseStudies_table4_Impoundments_', 
+write.csv(table_caseStudies, paste0(export_path, 'CaseStudies_table4_Impoundments_', 
                            demand_scenario, '_', baseline_scenario, '_', mif_coef, '.csv')) 
 
-write.csv(table_ups, paste0(export_path, 'CaseStudies_table5_Upstream_', 
+write.csv(table_csws, paste0(export_path, 'CaseStudies_table5_Upstream_', 
                            demand_scenario, '_', baseline_scenario, '_', mif_coef, '.csv')) 
 
 write.csv(table_update, paste0(export_path, 'CaseStudies_table6_UpdateSmin_', 
@@ -960,10 +960,10 @@ flextable::save_as_image(ftable_Smin, path = paste0(export_path, 'CaseStudies_ta
 flextable::save_as_image(ftable_Storage, path = paste0(export_path, 'CaseStudies_table3_Storage_', 
                                                   demand_scenario, '_', baseline_scenario, '_', mif_coef, '.png')) #table3
 
-flextable::save_as_image(ftable_imp, path = paste0(export_path, 'CaseStudies_table4_imp_', 
+flextable::save_as_image(table_caseStudies, path = paste0(export_path, 'CaseStudies_table4_imp_', 
                                                   demand_scenario, '_', baseline_scenario, '_', mif_coef, '.png')) #table4
 
-flextable::save_as_image(ftable_ups, path = paste0(export_path, 'CaseStudies_table5_ups_', 
+flextable::save_as_image(ftable_csws, path = paste0(export_path, 'CaseStudies_table5_ups_', 
                                                   demand_scenario, '_', baseline_scenario, '_', mif_coef, '.png')) #table5
 ```
 


### PR DESCRIPTION
Hey @glenncampagna I could not run the `caseStudies` branch, as it failed at the very end of the render in the last 2 sections where we were writing the CSV and image copies of the tables. The last 2 table writes were using variable names that were not yet defined.  I did my best to guess which tables you intended to write here, but since I don't really know which you wanted I am just making this PR so you can check it out and make the decision you see fit.  Feel free to delete this PR if it doesn't fix in the way that you prefer (looks like you have a naming convention in mind that I am not adhering to).

Side note: looks like the table sections in the Rmd `{ r Table X...` do not have the same order as the end section that writes them to files, and seems like something we'd want to bring into agreement in order to reduce possible confusion.