### PR TITLE
small tweaks to get interwoven tables and maps to show using code from VWP_CIA_Summary.Rmd

### DIFF
--- a/HARP-2023-Summer/Mapping/WSP_Regional_Summaries.Rmd
+++ b/HARP-2023-Summer/Mapping/WSP_Regional_Summaries.Rmd
@@ -764,8 +764,12 @@ for (k in 1:length(rivseg_metric)){
 ```{r View Rivseg Maps and Tables, out.width = '100%', out.height='100%', results='asis', echo=FALSE}
 for (k in 1:length(run_config$riverseg_metrics)){
   #map
+  show_map = run_config$riverseg_metrics[[k]]$show_map
   if (show_map == TRUE) {
-    knitr::include_graphics(rivmapfilename)
+    #fig_md = knitr::include_graphics(rivmapfilename)
+    fig_md = paste(paste0("![](",rivmapfilename[k],")"),"\n")
+  } else {
+    fig_md = ''
   }
     #table
     if (tablemessage2==TRUE) {
@@ -773,6 +777,7 @@ for (k in 1:length(run_config$riverseg_metrics)){
           likely meaning the metric requested is not modeled for this data
           or the segments are all tidal")
     }
+    cat(fig_md)
     cat(knitr::knit_print(get(paste0('table', k))))
     cat("\n\n\\pagebreak\n")
   }


### PR DESCRIPTION
@EllaF21 @gmahadwar @COBrogan 
I have made some tweaks to Ella's branch (see PR #1223 and issue #1222 ), to enable interweaving tables and maps.
It worked out nicely, I cribbed some code from the [VWP summary script](https://github.com/HARPgroup/vahydro/blob/master/R/examples/VWP_CIA_Summary.Rmd) (note: this script does a ton and there seems to be a number of techniques employed in it that solve some frustrating Rmd stuff, so it is a great resource).

The main tweaks I made was to 
- Stash the current map (or a blank string if `show_map == False`) in a variable `fig_md` using the graphics include syntax from [`VWP_CIA...`](https://github.com/HARPgroup/vahydro/blob/master/R/examples/VWP_CIA_Summary.Rmd)
- add a `[[k]]` subscript to the maps (it was printing all the maps at once)
- Use a `cat` command at the end of the loop to print the `fig_md` variables without an `if-then` structure since that seems to break knitting

If you all can check this out and see if it runs and does what you want let me know.  @EllaF21 I made this PR against your branch so that you can merge it in your self.  