### PR TITLE
added line breaks and indentation in saved json model

### DIFF
--- a/HARP-2024-2025/functions/mon_lm_analysis.R
+++ b/HARP-2024-2025/functions/mon_lm_analysis.R
@@ -39,7 +39,10 @@ sample_data <- read.csv(data_location)
 
 print("Running mon_lm function")
 data_lm <- mon_lm_stats(sample_data,y_var,x_var,mo_var)
-json_data_lm <- serializeJSON(data_lm)
+json_data_lm <- prettify(
+  serializeJSON(data_lm), 
+  indent = 2
+)
 print(paste0("Write json in new file path: ",json_write_path))
 write(json_data_lm, json_write_path)
 write.csv(data_lm$atts$stats, stats_write_path)


### PR DESCRIPTION
Hey @mwdunlap2004 and @COBrogan -- the lm() functions work great!! Here is a tweak that uses "prettify()" to add line breaks and indentation for the resulting json file for our models.  Note: the models are actually empty plotBin shell right now, but we can sort that out later.