### PR TITLE
Added a few lines in df generator to fix the five_yr_avg problem.

### DIFF
--- a/HARP-2023-Summer/Mapping/Dataframe_Generator.Rmd
+++ b/HARP-2023-Summer/Mapping/Dataframe_Generator.Rmd
@@ -193,10 +193,13 @@ if(featr_type == "source"){
 }
 if(featr_type == "facility"){ #get facility-level fiveyr_avg_mgy from foundatn_mp by summing all mp values for each facility:
   f_foundatn <- sqldf("select foundatn_mp.*,
-                    sum(five_yr_avg) as sum
+                    sum(five_yr_avg) as sum  -- Creating an aggregated column for the five_yr_avg
                     from foundatn_mp
                     group by Facility_hydroid
                   ") #all source-related data now only applies to 1 source (random) within the facil 
+  ## Need to replace the MP five_yr_avg with the aggregated column
+  f_foundatn$five_yr_avg <- f_foundatn$sum
+  
   f_foundatn$wsp_2020_2040_mgy <- f_foundatn$wsp_2040_mgy
   f_model <- sqldf("SELECT * FROM f_model WHERE hydrocode not like 'wsp_%'") #filter out WSP entries from facility-level model metric data
   f_model$Facility_hydroid <- f_model$featureid 


### PR DESCRIPTION
 As it was, it would create a new column to calculate facility five_yr_avg called sum, but then for Table 1 it would still pull the five_yr_avg column, which was at the MP level. It would pull this column because it looks for column names in the render statement. Ideal solution would be to rewrite the sqldf call and explicitely SELECT all relevant columns and replace the five_yr_avg column with an aggregate, but this is bulkier. Lines added simply replace the original five_yr_avg column with the aggregated one.