### PR TITLE
One reason a lot of facilities in Table 1.1 were showing a riverseg n…

### DIFF
--- a/HARP-2023-Summer/Mapping/WSP_Regional_Summaries.Rmd
+++ b/HARP-2023-Summer/Mapping/WSP_Regional_Summaries.Rmd
@@ -486,9 +486,9 @@ table$Locality = facils_table$Locality
 #add rivseg names
 for(i in 1:nrow(table)){ 
   loc_rivseg <- (rsegs[grep(facils_table$riverseg[i], rsegs$riverseg),]) #find rivseg in segs and compare to facils_table to add name
-  if (nrow(loc_rivseg) != 0) {
+  if (nrow(loc_rivseg) != 0 & facils_table$riverseg[i] != "" ) {
     table$`River Segment Name`[i] <- loc_rivseg$name
-  } else { # if no matching row was found for the riverseg ID, leave blank but don't break
+  } else { # if no matching row was found for the riverseg ID (or too many), leave blank but don't break
     table$`River Segment Name`[i] <- ""
     }
 }


### PR DESCRIPTION
…ame but no ID was due to the grep statement in line 490 that was used to define the riverseg name for the table. In the df generator output, in the facils file, there either would be a riverseg or it would be empty quotes. This riverseg was then sued in a grep statement to match up with the riverseg csv to get the ID. Problem is when empty quotes are put into a grep statement, it returns everything, and so it would just fill in with the first row. Once again, I did the simplest solution which was to add a conditional onto the if statement in that for loop for if the input was empty quotes. Could be rewritten better.