### PR TITLE
Attempts to fix dataframe generator after updates to Regions

### DIFF
--- a/HARP-2023-Summer/Mapping/Dataframe_Generator.Rmd
+++ b/HARP-2023-Summer/Mapping/Dataframe_Generator.Rmd
@@ -158,7 +158,7 @@ if(base_layer_data==TRUE){
 cnty_fips$name <- sub(" County", "", cnty_fips$name) # fix any names followed by " County" to match the names of counties in the regions df
 # rename Region col in base set to prevent conflict
 colnames(cnty_fips)[colnames(cnty_fips) == 'Region'] <- 'us_region'
-cnty_fips <- sqldf("SELECT a.*, b.VMDWA_Reg2 as Region
+cnty_fips <- sqldf("SELECT a.*, b.CPU as Region
                 FROM cnty_fips as a
                 LEFT OUTER JOIN cnty_regions as b
                 WHERE (a.name = b.County)
@@ -235,10 +235,12 @@ if(featr_type == "source"){
 if(featr_type == "facility"){ #get facility-level fiveyr_avg_mgy from foundatn_mp by summing all mp values for each facility:
   f_foundatn <- sqldf("
    SELECT facility_hydroid,CEDS_Facility_Id,facility,Use_Type,latitude,longitude,locality,facility_status,
-    Total_Permit_Limit_MGY,gw_frac,wsp2040_mgy AS wsp_2040_mgy,wsp2020_mgy AS wsp2020_2040_mgy,fac_CEDSid,
-    SUM(fiveyr_avg_mgy) as sum  -- Creating an aggregated column for the fiveyr_avg_mgy
+    Total_Permit_Limit_MGY,gw_frac,wsp_2040_mgy AS wsp_2040_mgy,wsp2020_2040_mgy AS wsp2020_2040_mgy,fac_CEDSid,
+    SUM(five_yr_avg) as sum  -- Creating an aggregated column for the fiveyr_avg_mgy
    FROM foundatn_mp
-   GROUP BY Facility_hydroid
+   GROUP BY Facility_hydroid,CEDS_Facility_Id,facility,Use_Type,latitude,longitude,
+   locality,facility_status,Total_Permit_Limit_MGY,gw_frac,
+   wsp_2040_mgy,wsp2020_2040_mgy,fac_CEDSid
   ") # Not selecting any source related fields, as these are innacurate to the facility (and even the soruce)
   ## Need to replace the MP five_yr_avg with the aggregated column 
   f_foundatn$five_yr_avg <- f_foundatn$sum


### PR DESCRIPTION
@BrendanBrogan I tried to run dataframe generator the other day and got several errors that seem to have resulted from the change in the regions data from the other week. These got my data frame up and running. I also fixed an SQLDF statement that did not have a proper group by clause on it.

My WSP summary still failed and I ran out of time to investigate that. Trying to run Northern Virginia summary as Andrew was seeing an error that I think we fixed a while back (in Andrew's version, Berryville has a 2020 plan value of 0.38 MGY when their model is set at 138 MGY now). My issue happened on lines 196 - 208 and seem to have resulted from the function `fn_nhd_labs`. There is an implicit global `nhd` in this function and the input `data` seems irrelevant (I'm not even sure what the `for` loop does as it doesn't seem to use the iterator `d`). See function here https://github.com/HARPgroup/HARParchive/blob/master/HARP-2023-Summer/Mapping/Functions/fn_nhd_labs.R